### PR TITLE
IPv6: fix payload length calculation

### DIFF
--- a/sipgrep.c
+++ b/sipgrep.c
@@ -679,11 +679,6 @@ void process(u_char *d, struct pcap_pkthdr *h, u_char *p) {
             data = (unsigned char *)(tcp_pkt) + tcphdr_offset;
             len -= link_offset + ip_hl + tcphdr_offset;
 
-#if USE_IPv6
-            if (ip_ver == 6)
-                len -= ntohs(ip6_pkt->ip6_plen);
-#endif
-
             if ((int32_t)len < 0)
                 len = 0;
 
@@ -698,11 +693,6 @@ void process(u_char *d, struct pcap_pkthdr *h, u_char *p) {
 
             data = (unsigned char *)(udp_pkt) + udphdr_offset;
             len -= link_offset + ip_hl + udphdr_offset;
-
-#if USE_IPv6
-            if (ip_ver == 6)
-                len -= ntohs(ip6_pkt->ip6_plen);
-#endif
 
             if ((int32_t)len < 0)
                 len = 0;


### PR DESCRIPTION
Checking a SIP IPv6 pcap file, the payload is not displayed at all.

I think the problem is that while calculating packet payload length with IPv6, you are considering the  payloadlen ipv6 header as the ipv6 length of the header. As far as I know, IPv6 headers have a fixed length of 40 octets that are already substracted from packet total length using `ip_hl` variable.

Not sure if this problem could be related with https://github.com/sipcapture/captagent/issues/6

The pcap I used for testing was [this](http://www.pcapr.net/view/amohan/2009/1/1/10/SIP_IPv6.cap.html), if you provide me an email I can resend it, in case you don't want to register.

Best regards,
Kaian