### PR TITLE
configure: fix USE_IPv6 after autoreconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,9 +66,8 @@ AC_ARG_ENABLE(ipv6,
 ]) 
 
 if test $use_ipv6 = yes; then
-   USE_IPv6="1"
-else
-   USE_IPv6="0"
+   AC_DEFINE(USE_IPv6, [1], [IPv6 (and ICMPv6) support])
+   AC_SUBST(USE_IPv6, yes)
 fi
 
 
@@ -264,6 +263,7 @@ echo $PACKAGE $VERSION
 echo
 echo Build directory............. : $sipgrep_builddir
 echo Installation prefix......... : $prefix
+echo IPv6 support.................: $use_ipv6
 echo HEP support................. : $enableHEP
 echo HEP Compression............. : $enableCompression
 echo SSL/TLS..................... : $enableSSL


### PR DESCRIPTION
I was forced to do `./build.sh` because missmatching libtool version in my system.
It seems the `--enable-ipv6` flag was not exporting its value to src/config.h correctly.

I haven't do the else part with 0 value with this define, because I think the code just checks if the define exists. Also I have added the support string to the final flags summary.

Best regards,
Kaian