### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
-
+arch:
+  - amd64
+  - ppc64le
 compiler:
   - gcc
 


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf on IBM . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/sipgrep/builds/208660347 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!